### PR TITLE
reformat dbconnection.query

### DIFF
--- a/src/setData.js
+++ b/src/setData.js
@@ -9,7 +9,9 @@ function setData(body, cb) {
     return acc;
   }, {});
 
-dbconnection.query(`INSERT INTO companies (company_name, reason, location, author_id) VALUES ('${dataObj.company}', '${dataObj.reason}', 'not known', (SELECT authors.id FROM authors WHERE authors.first_name = '${dataObj.name}'))`,
+dbconnection.query(`INSERT INTO companies (company_name, reason, location, author_id) 
+                    VALUES ('${dataObj.company}', '${dataObj.reason}', 'not known', 
+                    (SELECT authors.id FROM authors WHERE authors.first_name = '${dataObj.name}'))`,
   (err,res) => {
     if (err) cb(err);
     else cb (null, res);


### PR DESCRIPTION
Our dbconnection.query was 231 characters long, each line should only really be 80 chars long. 

It's now been split over multiple lines.

Relates #64